### PR TITLE
FIXES: fixed bugs and added features for move_cartesian method for Universal Robots

### DIFF
--- a/armctl/universal_robots/universal_robots.py
+++ b/armctl/universal_robots/universal_robots.py
@@ -167,22 +167,12 @@ class UniversalRobots(SCT, Commands, Properties):
         # if self.send_command("is_within_safety_limits({})\n".format(','.join(map(str, pose)))) == "False":
         #     raise ValueError("Cartesian position out of safety limits")
 
-        ''' Note: Since both the joint values (q) and the pose are list with num. of elements = 6
-            It is imperative to make a clear distinction between the two.
-            Acc. to UR script manual joint values are passed normally as a list with 6 elements.
-            The pose values are prefixed with a 'p' as :  p[X, Y, Z, Rx, Ry, Rz]
-            movel/movep/movej allows both pose and joint values as arguments.
-            Forward/Inverse Kinematics is later employed to move to desired pose/joint config depending on input.
-        '''
-        if move_type=="movel":
-            command = f"{move_type}(p[{','.join(map(str, pose))}], a={acceleration}, v={speed}, t={time}, r={radius})\n"
-        elif move_type=="movej":
+        # Note: 'p' prefix designates pose
+        # Command Format: "p[X, Y, Z, Rx, Ry, Rz]"
+        if move_type in ("movel", "movej"):
             command = f"{move_type}(p[{','.join(map(str, pose))}], a={acceleration}, v={speed}, t={time}, r={radius})\n"
         elif move_type=="movep":
             command = f"{move_type}(p[{','.join(map(str, pose))}], a={acceleration}, v={speed}, r={radius})\n"
-        else:
-            logger.info("Unsupported move type")
-
         self.send_command(command, suppress_output=True)
 
         # while not all(round(a, 2) == round(b, 2) for a, b in zip(self.get_cartesian_position(), pose)):


### PR DESCRIPTION
After extensive testing as per my requirements for Universal Robots using this library, I encountered certain bugs  and added one extra feature. 

1. Since both the joint values (q) and the pose are list with number of elements = 6. It is imperative to make a clear distinction between the two. According to UR script manual; joint values are passed normally as a list with 6 elements as **q=[q1,q2,q3,q4,q5,q6]**. The pose values are prefixed with a 'p' as :  **p[X, Y, Z, Rx, Ry, Rz]**. **movel/movep/movej** allows both pose and joint values as arguments. Forward/Inverse Kinematics is later employed to move to desired pose/joint config depending on input.
2. Added the **movej** type method as well, since it allows for better joint optimization specially during teleoperation/operator tracking
3. The **movep** method only takes *acceleration, velocity* and *radius* as arguments in contrary to **movel/movej** which takes *time* as an additional argument.

Please feel free to review the changes. Willing to add more features with time.

